### PR TITLE
Updated only owner can see total voters during election

### DIFF
--- a/contracts/NUSElections.sol
+++ b/contracts/NUSElections.sol
@@ -252,6 +252,9 @@ contract NUSElections {
     }
 
     function getCurrentNumVoters() public view returns(uint256) {
+        if (!electionStatus) {
+            require(msg.sender == electionOwner, "Election ongoing, only election owner can see total number of voters during an election.");
+        }
         return voterList.length;
     }
 


### PR DESCRIPTION
NUSElection.sol
getCurrentNumVoters() - Updated function to ensure that only owner can see total number of voters during an election. Voters can only see after the election (See 3.5 **First come first serve basis for voting rewards** for the details)

3_test_nuselections.js 
Added these test cases:
1. Voters cannot see the total number of voters when the election is ongoing
2. Only election owner can see total number of voters when the election is ongoing
3. Voters can see total number of voters after election has ended

All test cases pass